### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: macOS-latest
     outputs:
       PACKAGE_NAME: ${{ steps.build-vars.outputs.PACKAGE_NAME }}
@@ -15,10 +16,12 @@ jobs:
       BUILD_NUMBER: ${{ steps.build-vars.outputs.BUILD_NUMBER }}
     strategy:
       matrix:
-        target: ['iOS', 'tvOS', 'watchOS']
+        target: [ "iOS", "tvOS", "watchOS" ]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set build variables
+    - name: Checkout
+      uses: actions/checkout@v4.1.1
+
+    - name: Set Build Variables
       id: build-vars
       env:
         TAG_NAME: ${{ github.ref }}
@@ -30,38 +33,38 @@ jobs:
         export PACKAGE_VERSION="${PACKAGE_NAME_VERSION#*-}"
         export BUILD_NUMBER="${TAG#*-*-}"
 
-        echo "PACKAGE_NAME=${PACKAGE_NAME}"
-        echo "PACKAGE_VERSION=${PACKAGE_VERSION}"
-        echo "BUILD_NUMBER=${BUILD_NUMBER}"
+        echo "PACKAGE_NAME=${PACKAGE_NAME}" | tee -a ${GITHUB_OUTPUT}
+        echo "PACKAGE_VERSION=${PACKAGE_VERSION}" | tee -a ${GITHUB_OUTPUT}
+        echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a ${GITHUB_OUTPUT}
 
-        echo "PACKAGE_NAME=${PACKAGE_NAME}" >> ${GITHUB_OUTPUT}
-        echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> ${GITHUB_OUTPUT}
-        echo "BUILD_NUMBER=${BUILD_NUMBER}" >> ${GITHUB_OUTPUT}
     - name: Set up Python
       uses: actions/setup-python@v5.0.0
       with:
         python-version: "3.X"
+
     - name: Build ${{ matrix.target }}
       run: |
         # Do the build for the requested target.
         make ${{ steps.build-vars.outputs.PACKAGE_NAME }}-${{ matrix.target }} $(echo "${{ steps.build-vars.outputs.PACKAGE_NAME }}" | tr 'a-z' 'A-Z')_VERSION=${{ steps.build-vars.outputs.PACKAGE_VERSION }} BUILD_NUMBER=${{ steps.build-vars.outputs.BUILD_NUMBER }}
 
-    - name: Upload build artifact
-      uses: actions/upload-artifact@v3.1.3
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v4.0.0
       with:
-        name: dist
-        path: "dist"
+        name: dist-${{ matrix.target }}
+        path: dist
         if-no-files-found: error
 
   make-release:
-    runs-on: ubuntu-latest
+    name: Make Release
     needs: build
+    runs-on: ubuntu-latest
     steps:
-    - name: Get build artifacts
-      uses: actions/download-artifact@v3.0.2
+    - name: Get Build Artifacts
+      uses: actions/download-artifact@v4.1.0
       with:
-        name: dist
+        pattern: dist-*
         path: dist
+        merge-multiple: true
 
     - name: Create Release
       uses: ncipollo/release-action@v1.13.0


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- To accommodate v4:
  - Artifacts must have unique names since multiple uploads cannot contribute to a single artifact
  - Use a wildcard pattern to download all artifacts and merge in to a single directory

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct
