### PR TITLE
Add support for visionOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [ "iOS", "tvOS", "watchOS","xrOS" ]
+        target: [ "iOS", "tvOS", "watchOS", "visionOS" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macOS-latest
     strategy:
       matrix:
-        target: [ "iOS", "tvOS", "watchOS" ]
+        target: [ "iOS", "tvOS", "watchOS","xrOS" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       BUILD_NUMBER: ${{ steps.build-vars.outputs.BUILD_NUMBER }}
     strategy:
       matrix:
-        target: [ "iOS", "tvOS", "watchOS", "xrOS" ]
+        target: [ "iOS", "tvOS", "watchOS", "visionOS" ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4.2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       BUILD_NUMBER: ${{ steps.build-vars.outputs.BUILD_NUMBER }}
     strategy:
       matrix:
-        target: [ "iOS", "tvOS", "watchOS" ]
+        target: [ "iOS", "tvOS", "watchOS", "xrOS" ]
     steps:
     - name: Checkout
       uses: actions/checkout@v4.2.2

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ PYTHON_CONFIGURE-watchOS=ac_cv_func_sigaltstack=no
 
 # xrOS targets
 TARGETS-xrOS=xrsimulator.arm64 xros.arm64
-VERSION_MIN-xrOS=4.0
+VERSION_MIN-xrOS=2.0
 # I don't know the version-min flag for xros, seems to work fine without it
 PYTHON_CONFIGURE-xrOS=ac_cv_func_sigaltstack=no
 

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@
 # - iOS             - build everything for iOS
 # - tvOS            - build everything for tvOS
 # - watchOS         - build everything for watchOS
-# - xrOS            - build everything for xrOS
+# - visionOS        - build everything for visionOS
 # - BZip2           - build BZip2 for all platforms
 # - BZip2-iOS       - build BZip2 for iOS
 # - BZip2-tvOS      - build BZip2 for tvOS
 # - BZip2-watchOS   - build BZip2 for watchOS
-# - BZip2-xrOS      - build BZip2 for xrOS
+# - BZip2-visionOS  - build BZip2 for visionOS
 # - XZ              - build XZ for all platforms
 # - XZ-iOS          - build XZ for iOS
 # - XZ-tvOS         - build XZ for tvOS
@@ -19,23 +19,23 @@
 # - OpenSSL-iOS     - build OpenSSL for iOS
 # - OpenSSL-tvOS    - build OpenSSL for tvOS
 # - OpenSSL-watchOS - build OpenSSL for watchOS
-# - OpenSSL-xrOS    - build OpenSSL for xrOS
+# - OpenSSL-visionOS- build OpenSSL for visionOS
 # - mpdecimal         - build mpdecimal for all platforms
 # - mpdecimal-iOS     - build mpdecimal for iOS
 # - mpdecimal-tvOS    - build mpdecimal for tvOS
 # - mpdecimal-watchOS - build mpdecimal for watchOS
-# - mpdecimal-xrOS    - build mpdecimal for xrOS
+# - mpdecimal-visionOS- build mpdecimal for visionOS
 # - libFFI-iOS      - build libFFI for iOS
 # - libFFI-tvOS     - build libFFI for tvOS
 # - libFFI-watchOS  - build libFFI for watchOS
-# - libFFI-xrOS     - build libFFI for xrOS
+# - libFFI-visionOS - build libFFI for visionOS
 
 # Current directory
 PROJECT_DIR=$(shell pwd)
 
 # Supported OS and products
 PRODUCTS=BZip2 XZ OpenSSL libFFI
-OS_LIST=iOS tvOS watchOS xrOS
+OS_LIST=iOS tvOS watchOS visionOS
 
 # The versions to compile by default.
 # In practice, these should be
@@ -79,10 +79,10 @@ VERSION_MIN-watchOS=4.0
 CFLAGS-watchOS=-mwatchos-version-min=$(VERSION_MIN-watchOS)
 PYTHON_CONFIGURE-watchOS=ac_cv_func_sigaltstack=no
 
-# xrOS targets
-TARGETS-xrOS=xrsimulator.arm64 xros.arm64
-VERSION_MIN-xrOS=2.0
-# I don't know the version-min flag for xros, seems to work fine without it
+# visionOS targets
+TARGETS-visionOS=xrsimulator.arm64 xros.arm64
+VERSION_MIN-visionOS=2.0
+# Apple made lives harder by NOT having a -version-min flag
 PYTHON_CONFIGURE-xrOS=ac_cv_func_sigaltstack=no
 
 # The architecture of the machine doing the build

--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,38 @@
 # - iOS             - build everything for iOS
 # - tvOS            - build everything for tvOS
 # - watchOS         - build everything for watchOS
+# - xrOS            - build everything for xrOS
 # - BZip2           - build BZip2 for all platforms
 # - BZip2-iOS       - build BZip2 for iOS
 # - BZip2-tvOS      - build BZip2 for tvOS
 # - BZip2-watchOS   - build BZip2 for watchOS
+# - BZip2-xrOS      - build BZip2 for xrOS
 # - XZ              - build XZ for all platforms
 # - XZ-iOS          - build XZ for iOS
 # - XZ-tvOS         - build XZ for tvOS
 # - XZ-watchOS      - build XZ for watchOS
+# - XZ-xrOS         - build XZ for xrOS
 # - OpenSSL         - build OpenSSL for all platforms
 # - OpenSSL-iOS     - build OpenSSL for iOS
 # - OpenSSL-tvOS    - build OpenSSL for tvOS
 # - OpenSSL-watchOS - build OpenSSL for watchOS
+# - OpenSSL-xrOS    - build OpenSSL for xrOS
 # - mpdecimal         - build mpdecimal for all platforms
 # - mpdecimal-iOS     - build mpdecimal for iOS
 # - mpdecimal-tvOS    - build mpdecimal for tvOS
 # - mpdecimal-watchOS - build mpdecimal for watchOS
+# - mpdecimal-xrOS    - build mpdecimal for xrOS
 # - libFFI-iOS      - build libFFI for iOS
 # - libFFI-tvOS     - build libFFI for tvOS
 # - libFFI-watchOS  - build libFFI for watchOS
+# - libFFI-xrOS     - build libFFI for xrOS
 
 # Current directory
 PROJECT_DIR=$(shell pwd)
 
 # Supported OS and products
 PRODUCTS=BZip2 XZ OpenSSL libFFI
-OS_LIST=iOS tvOS watchOS
+OS_LIST=iOS tvOS watchOS xrOS
 
 # The versions to compile by default.
 # In practice, these should be
@@ -72,6 +78,12 @@ TARGETS-watchOS=watchsimulator.x86_64 watchsimulator.arm64 watchos.arm64_32
 VERSION_MIN-watchOS=4.0
 CFLAGS-watchOS=-mwatchos-version-min=$(VERSION_MIN-watchOS)
 PYTHON_CONFIGURE-watchOS=ac_cv_func_sigaltstack=no
+
+# xrOS targets
+TARGETS-xrOS=xrsimulator.arm64 xros.arm64
+VERSION_MIN-xrOS=4.0
+# I don't know the version-min flag for xros, seems to work fine without it
+PYTHON_CONFIGURE-xrOS=ac_cv_func_sigaltstack=no
 
 # The architecture of the machine doing the build
 HOST_ARCH=$(shell uname -m)
@@ -550,6 +562,7 @@ $$(LIBFFI_SRCDIR-$(os))/darwin_common/include/ffi.h: downloads/libffi-$(LIBFFI_V
 	@echo ">>> Unpack and configure libFFI sources on $(os)"
 	mkdir -p $$(LIBFFI_SRCDIR-$(os))
 	tar zxf $$< --strip-components 1 -C $$(LIBFFI_SRCDIR-$(os))
+	cd $$(LIBFFI_SRCDIR-$(os)) && patch -p1 < $(PROJECT_DIR)/patch/libffi.patch
 	# Configure the build
 	cd $$(LIBFFI_SRCDIR-$(os)) && \
 		python3 generate-darwin-source-and-headers.py --only-$(shell echo $(os) | tr '[:upper:]' '[:lower:]') \

--- a/patch/libffi.patch
+++ b/patch/libffi.patch
@@ -1,0 +1,94 @@
+diff -ur libffi-3.4.7 2/config.sub libffi-3.4.7/config.sub
+--- libffi-3.4.7 2/config.sub	2024-12-13 04:38:19
++++ libffi-3.4.7/config.sub	2025-04-12 17:44:40
+@@ -1742,7 +1742,7 @@
+ 	     | hpux* | unos* | osf* | luna* | dgux* | auroraux* | solaris* \
+ 	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
+ 	     | hiux* | abug | nacl* | netware* | windows* \
+-	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* \
+ 	     | mpw* | magic* | mmixware* | mon960* | lnews* \
+ 	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
+ 	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
+@@ -1864,7 +1864,7 @@
+ 		;;
+ 	os2-emx-)
+ 		;;
+-	ios*-simulator* | tvos*-simulator* | watchos*-simulator*)
++	ios*-simulator* | tvos*-simulator* | watchos*-simulator* | xros*-simulator*)
+ 		;;	
+ 	*-eabi*- | *-gnueabi*-)
+ 		;;
+diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/generate-darwin-source-and-headers.py
+--- libffi-3.4.7 2/generate-darwin-source-and-headers.py	2024-06-01 12:42:02
++++ libffi-3.4.7/generate-darwin-source-and-headers.py	2025-04-12 18:02:51
+@@ -152,8 +152,22 @@
+     sdk = 'watchos'
+     arch = 'arm64_32'
+     version_min = '-mwatchos-version-min=4.0'
++    
++class xros_simulator_arm64_platform(arm64_platform):
++    target = 'arm64-apple-xros-simulator'
++    directory = 'darwin_xros'
++    sdk = 'xrsimulator'
++    version_min = ''
+ 
+ 
++class xros_device_arm64_platform(arm64_platform):
++    target = 'arm64-apple-xros'
++    directory = 'darwin_xros'
++    sdk = 'xros'
++    arch = 'arm64'
++    version_min = ''
++
++
+ def mkdir_p(path):
+     try:
+         os.makedirs(path)
+@@ -243,6 +257,7 @@
+     generate_ios=True,
+     generate_tvos=True,
+     generate_watchos=True,
++    generate_xros=True
+ ):
+     copy_files('src', 'darwin_common/src', pattern='*.c')
+     copy_files('include', 'darwin_common/include', pattern='*.h')
+@@ -266,6 +281,9 @@
+         copy_src_platform_files(watchos_simulator_arm64_platform)
+         copy_src_platform_files(watchos_device_armv7k_platform)
+         copy_src_platform_files(watchos_device_arm64_32_platform)
++    if generate_xros:
++        copy_src_platform_files(xros_simulator_arm64_platform)
++        copy_src_platform_files(xros_device_arm64_platform)
+ 
+     platform_headers = collections.defaultdict(set)
+ 
+@@ -288,6 +306,9 @@
+         build_target(watchos_simulator_arm64_platform, platform_headers)
+         build_target(watchos_device_armv7k_platform, platform_headers)
+         build_target(watchos_device_arm64_32_platform, platform_headers)
++    if generate_xros:
++        build_target(xros_simulator_arm64_platform, platform_headers)
++        build_target(xros_device_arm64_platform, platform_headers)
+ 
+     mkdir_p('darwin_common/include')
+     for header_name, tag_tuples in platform_headers.items():
+@@ -302,11 +323,13 @@
+     parser.add_argument('--only-osx', action='store_true', default=False)
+     parser.add_argument('--only-tvos', action='store_true', default=False)
+     parser.add_argument('--only-watchos', action='store_true', default=False)
++    parser.add_argument('--only-xros', action='store_true', default=False)
+     args = parser.parse_args()
+ 
+     generate_source_and_headers(
+-        generate_osx=not args.only_ios and not args.only_tvos and not args.only_watchos,
+-        generate_ios=not args.only_osx and not args.only_tvos and not args.only_watchos,
+-        generate_tvos=not args.only_ios and not args.only_osx and not args.only_watchos,
+-        generate_watchos=not args.only_ios and not args.only_osx and not args.only_tvos,
++        generate_osx=not args.only_ios and not args.only_tvos and not args.only_watchos and not args.only_xros,
++        generate_ios=not args.only_osx and not args.only_tvos and not args.only_watchos and not args.only_xros,
++        generate_tvos=not args.only_ios and not args.only_osx and not args.only_watchos and not args.only_xros,
++        generate_watchos=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_xros,
++        generate_xros=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_watchos,
+     )
+

--- a/patch/libffi.patch
+++ b/patch/libffi.patch
@@ -6,7 +6,7 @@ diff -ur libffi-3.4.7 2/config.sub libffi-3.4.7/config.sub
  	     | sym* |  plan9* | psp* | sim* | xray* | os68k* | v88r* \
  	     | hiux* | abug | nacl* | netware* | windows* \
 -	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
-+	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* | visionos* \
  	     | mpw* | magic* | mmixware* | mon960* | lnews* \
  	     | amigaos* | amigados* | msdos* | newsos* | unicos* | aof* \
  	     | aos* | aros* | cloudabi* | sortix* | twizzler* \
@@ -15,7 +15,7 @@ diff -ur libffi-3.4.7 2/config.sub libffi-3.4.7/config.sub
  	os2-emx-)
  		;;
 -	ios*-simulator* | tvos*-simulator* | watchos*-simulator*)
-+	ios*-simulator* | tvos*-simulator* | watchos*-simulator* | xros*-simulator*)
++	ios*-simulator* | tvos*-simulator* | watchos*-simulator* | xros*-simulator* | visionos*-simulator*)
  		;;	
  	*-eabi*- | *-gnueabi*-)
  		;;
@@ -27,16 +27,16 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
      arch = 'arm64_32'
      version_min = '-mwatchos-version-min=4.0'
 +    
-+class xros_simulator_arm64_platform(arm64_platform):
-+    target = 'arm64-apple-xros-simulator'
-+    directory = 'darwin_xros'
++class visionos_simulator_arm64_platform(arm64_platform):
++    target = 'arm64-apple-visionos-simulator'
++    directory = 'darwin_visionos'
 +    sdk = 'xrsimulator'
 +    version_min = ''
  
  
-+class xros_device_arm64_platform(arm64_platform):
-+    target = 'arm64-apple-xros'
-+    directory = 'darwin_xros'
++class visionos_device_arm64_platform(arm64_platform):
++    target = 'arm64-apple-visionos'
++    directory = 'darwin_visionos'
 +    sdk = 'xros'
 +    arch = 'arm64'
 +    version_min = ''
@@ -49,7 +49,7 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
      generate_ios=True,
      generate_tvos=True,
      generate_watchos=True,
-+    generate_xros=True
++    generate_visionos=True
  ):
      copy_files('src', 'darwin_common/src', pattern='*.c')
      copy_files('include', 'darwin_common/include', pattern='*.h')
@@ -57,9 +57,9 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
          copy_src_platform_files(watchos_simulator_arm64_platform)
          copy_src_platform_files(watchos_device_armv7k_platform)
          copy_src_platform_files(watchos_device_arm64_32_platform)
-+    if generate_xros:
-+        copy_src_platform_files(xros_simulator_arm64_platform)
-+        copy_src_platform_files(xros_device_arm64_platform)
++    if generate_visionos:
++        copy_src_platform_files(visionos_simulator_arm64_platform)
++        copy_src_platform_files(visionos_device_arm64_platform)
  
      platform_headers = collections.defaultdict(set)
  
@@ -67,9 +67,9 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
          build_target(watchos_simulator_arm64_platform, platform_headers)
          build_target(watchos_device_armv7k_platform, platform_headers)
          build_target(watchos_device_arm64_32_platform, platform_headers)
-+    if generate_xros:
-+        build_target(xros_simulator_arm64_platform, platform_headers)
-+        build_target(xros_device_arm64_platform, platform_headers)
++    if generate_visionos:
++        build_target(visionos_simulator_arm64_platform, platform_headers)
++        build_target(visionos_device_arm64_platform, platform_headers)
  
      mkdir_p('darwin_common/include')
      for header_name, tag_tuples in platform_headers.items():
@@ -77,7 +77,7 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
      parser.add_argument('--only-osx', action='store_true', default=False)
      parser.add_argument('--only-tvos', action='store_true', default=False)
      parser.add_argument('--only-watchos', action='store_true', default=False)
-+    parser.add_argument('--only-xros', action='store_true', default=False)
++    parser.add_argument('--only-visionos', action='store_true', default=False)
      args = parser.parse_args()
  
      generate_source_and_headers(
@@ -85,10 +85,10 @@ diff -ur libffi-3.4.7 2/generate-darwin-source-and-headers.py libffi-3.4.7/gener
 -        generate_ios=not args.only_osx and not args.only_tvos and not args.only_watchos,
 -        generate_tvos=not args.only_ios and not args.only_osx and not args.only_watchos,
 -        generate_watchos=not args.only_ios and not args.only_osx and not args.only_tvos,
-+        generate_osx=not args.only_ios and not args.only_tvos and not args.only_watchos and not args.only_xros,
-+        generate_ios=not args.only_osx and not args.only_tvos and not args.only_watchos and not args.only_xros,
-+        generate_tvos=not args.only_ios and not args.only_osx and not args.only_watchos and not args.only_xros,
-+        generate_watchos=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_xros,
-+        generate_xros=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_watchos,
++        generate_osx=not args.only_ios and not args.only_tvos and not args.only_watchos and not args.only_visionos,
++        generate_ios=not args.only_osx and not args.only_tvos and not args.only_watchos and not args.only_visionos,
++        generate_tvos=not args.only_ios and not args.only_osx and not args.only_watchos and not args.only_visionos,
++        generate_watchos=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_visionos,
++        generate_visionos=not args.only_ios and not args.only_osx and not args.only_tvos and not args.only_watchos,
      )
 

--- a/patch/mpdecimal.patch
+++ b/patch/mpdecimal.patch
@@ -10,12 +10,17 @@ diff -ur mpdecimal-4.0.0-orig/config.sub mpdecimal-4.0.0/config.sub
  		cpu=aarch64
  		;;
  
+@@ -1713,3 +1713,3 @@
+ 	     | hiux* | abug | nacl* | netware* | windows* \
+-	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchOS* | xros* \
+ 	     | mpw* | magic* | mmixware* | mon960* | lnews* \
 @@ -1792,6 +1792,8 @@
  	os2-emx)
  		;;
  	*-eabi* | *-gnueabi*)
 +		;;
-+	ios*-simulator | tvos*-simulator | watchos*-simulator)
++	ios*-simulator | tvos*-simulator | watchos*-simulator | xros*-simulator)
  		;;
  	none-coff* | none-elf*)
  		# None (no kernel, i.e. freestanding / bare metal),

--- a/patch/mpdecimal.patch
+++ b/patch/mpdecimal.patch
@@ -13,7 +13,7 @@ diff -ur mpdecimal-4.0.0-orig/config.sub mpdecimal-4.0.0/config.sub
 @@ -1713,3 +1713,3 @@
  	     | hiux* | abug | nacl* | netware* | windows* \
 -	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
-+	     | os9* | macos* | osx* | ios* | tvos* | watchOS* | xros* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* \
  	     | mpw* | magic* | mmixware* | mon960* | lnews* \
 @@ -1792,6 +1792,8 @@
  	os2-emx)

--- a/patch/mpdecimal.patch
+++ b/patch/mpdecimal.patch
@@ -13,14 +13,14 @@ diff -ur mpdecimal-4.0.0-orig/config.sub mpdecimal-4.0.0/config.sub
 @@ -1713,3 +1713,3 @@
  	     | hiux* | abug | nacl* | netware* | windows* \
 -	     | os9* | macos* | osx* | ios* | tvos* | watchos* \
-+	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* \
++	     | os9* | macos* | osx* | ios* | tvos* | watchos* | xros* | visionos* \
  	     | mpw* | magic* | mmixware* | mon960* | lnews* \
 @@ -1792,6 +1792,8 @@
  	os2-emx)
  		;;
  	*-eabi* | *-gnueabi*)
 +		;;
-+	ios*-simulator | tvos*-simulator | watchos*-simulator | xros*-simulator)
++	ios*-simulator | tvos*-simulator | watchos*-simulator | xros*-simulator | visionos*-simulator)
  		;;
  	none-coff* | none-elf*)
  		# None (no kernel, i.e. freestanding / bare metal),

--- a/patch/xz.patch
+++ b/patch/xz.patch
@@ -10,12 +10,16 @@ diff -ru xz-5.4.7-orig/build-aux/config.sub xz-5.4.7/build-aux/config.sub
  		cpu=aarch64
  		;;
  
+@@ -2150,2 +2150,3 @@
+ 	| xray* \
++	| xros* \
+ 	| zephyr* \
 @@ -1865,6 +1865,8 @@
  	os2-emx-)
  		;;
  	*-eabi*- | *-gnueabi*-)
 +		;;
-+	ios*-simulator- | tvos*-simulator- | watchos*-simulator- )
++	ios*-simulator- | tvos*-simulator- | watchos*-simulator- | xros*-simulator-)
  		;;
  	none--*)
  		# None (no kernel, i.e. freestanding / bare metal),

--- a/patch/xz.patch
+++ b/patch/xz.patch
@@ -12,14 +12,14 @@ diff -ru xz-5.4.7-orig/build-aux/config.sub xz-5.4.7/build-aux/config.sub
  
 @@ -2150,2 +2150,3 @@
  	| xray* \
-+	| xros* \
++	| xros* | visionos* \
  	| zephyr* \
 @@ -1865,6 +1865,8 @@
  	os2-emx-)
  		;;
  	*-eabi*- | *-gnueabi*-)
 +		;;
-+	ios*-simulator- | tvos*-simulator- | watchos*-simulator- | xros*-simulator-)
++	ios*-simulator- | tvos*-simulator- | watchos*-simulator- | xros*-simulator- | visionos*-simulator- )
  		;;
  	none--*)
  		# None (no kernel, i.e. freestanding / bare metal),


### PR DESCRIPTION
<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

Fixes #49.

I couldn't figure out what the minimum version arg for visionOS is, so I omitted it from the FFI patch I created.

Also, it looks like xxx-CFLAGS is useless in the Makefile so I removed these as well.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] All new features have been tested
- [ ] All new features have been documented
- [X ] I have read the **CONTRIBUTING.md** file
- [X ] I will abide by the code of conduct
