### PR TITLE
Document Mac Catalyst Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,15 @@ This should enable the code to run on:
     * iPad Mini (2 or later)
     * iPad Pro (all models)
     * iPod Touch (7th gen or later)
+* Mac Catalyst 14.2 (macOS 11) or later, on:
+    * MacBook (2015 or later)
+    * MacBook Air (2013 or later)
+    * MacBook Pro (Late 2013 or later)
+    * Mac mini (2014 or later)
+    * iMac (2014 or later)
+    * iMac Pro (2017 or later)
+    * Mac Pro (2013 or later)
+    * Mac Studio
 * tvOS 9.0 or later, on:
     * Apple TV (4th gen or later)
 * watchOS 4.0 or later, on:

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ This should enable the code to run on:
     * iPad Mini (2 or later)
     * iPad Pro (all models)
     * iPod Touch (7th gen or later)
-* Mac Catalyst 14.2 (macOS 11) or later, on:
+* macOS 11 or later, using **Mac Catalyst** (14.2 or later), on:
     * MacBook (2015 or later)
     * MacBook Air (2013 or later)
     * MacBook Pro (Late 2013 or later)

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ This should enable the code to run on:
     * iPad Mini (2 or later)
     * iPad Pro (all models)
     * iPod Touch (7th gen or later)
-* macOS 11 or later, using *Mac Catalyst* (14.2 or later), on:
+* macOS 11 or later, using Mac Catalyst (14.2 or later), on:
     * MacBook (2015 or later)
     * MacBook Air (2013 or later)
     * MacBook Pro (Late 2013 or later)

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ This should enable the code to run on:
     * iPad Mini (2 or later)
     * iPad Pro (all models)
     * iPod Touch (7th gen or later)
-* macOS 11 or later, using **Mac Catalyst** (14.2 or later), on:
+* macOS 11 or later, using *Mac Catalyst* (14.2 or later), on:
     * MacBook (2015 or later)
     * MacBook Air (2013 or later)
     * MacBook Pro (Late 2013 or later)


### PR DESCRIPTION
I extremely apologize for the large number of PRs I opened these days (part of it attributable to the amount of separate repos, but I think the current structure works great!).

This documents support for Mac Catalyst. macOS 11 value is obtained by building a stub framework w/ iOS version set to 14.2 -- it returns 11.0.

List of Macs supporting macOS 11 is obtained from https://support.apple.com/en-us/111980, with Mac Studio added (since it's not in this list but is in the Python-Apple-Support list.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
